### PR TITLE
fix: Positioned ウィジェットの扱い方誤り

### DIFF
--- a/packages/hackathon_app/lib/spot_difference/ui/room_switching.dart
+++ b/packages/hackathon_app/lib/spot_difference/ui/room_switching.dart
@@ -78,17 +78,13 @@ class WaitingRoomUI extends ConsumerWidget {
                         textAlign: TextAlign.center,
                       ),
                     ),
-                    Positioned.fill(
-                      child: IgnorePointer(
-                        child: Lottie.asset(
-                          'assets/lottie/loading.json',
-                          width: 550,
-                          height: 550,
-                          repeat: true,
-                          reverse: false,
-                          animate: true,
-                        ),
-                      ),
+                    Lottie.asset(
+                      'assets/lottie/loading.json',
+                      width: 550,
+                      height: 550,
+                      repeat: true,
+                      reverse: false,
+                      animate: true,
                     ),
                     if (userId == room.createdByAppUserId)
                       Center(


### PR DESCRIPTION
Positioned Widget は Stack 上での使用が推奨されているが、今回は ListView であったため Positioned Widget を削除。
Lottie が デプロイ後の Flutter Web でも表示されることを確認。